### PR TITLE
Fixed a DLL hijacking related security issue

### DIFF
--- a/wrapper/cApiWrapper.cpp
+++ b/wrapper/cApiWrapper.cpp
@@ -88,7 +88,7 @@ ctlInit(
 #ifdef WINDOWS_UWP
             hinstLib = LoadPackagedLibrary(strDLLPath, 0);
 #else
-            hinstLib = LoadLibraryW(strDLLPath);
+            hinstLib = LoadLibraryExW(strDLLPath, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 #endif
             if (NULL == hinstLib)
             {

--- a/wrapper/cApiWrapper.cpp
+++ b/wrapper/cApiWrapper.cpp
@@ -88,7 +88,13 @@ ctlInit(
 #ifdef WINDOWS_UWP
             hinstLib = LoadPackagedLibrary(strDLLPath, 0);
 #else
-            hinstLib = LoadLibraryExW(strDLLPath, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+            DWORD dwFlags = 0;
+#ifdef _DEBUG
+            dwFlags = LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_APPLICATION_DIR;
+#else
+            dwFlags = LOAD_LIBRARY_SEARCH_SYSTEM32;
+#endif
+            hinstLib = LoadLibraryExW(strDLLPath, NULL, dwFlags);
 #endif
             if (NULL == hinstLib)
             {


### PR DESCRIPTION
Fixed a DLL hijacking related security issue while calling 'LoadLibrary()' API. The DLL hijacking will cause to inject malicious code into an application by exploiting the way Windows applications search and load Dynamic Link Libraries (DLL).To fix this issue used 'LoadLibraryEx()' API , and specified the exact DLL Search directory as Windows-System32 directory by using the flag 'LOAD_LIBRARY_SEARCH_SYSTEM32'. So the application won't look any other default directory to load the DLL and avoid the DLL hijack attack. We need your support to merge this PR soon so that we are able to use the Intel IGCL API Wrapper source code mentioned in Intel API documentation - https://intel.github.io/drivers.gpu.control-library/Control/INTRO.html#fundamentals
Thanks in Advance.