### PR TITLE
Fixed BlockNumber in Panel_descriptor_Sample_App

### DIFF
--- a/Samples/Panel_descriptor_Samples/Panel_descriptor_Sample_App.cpp
+++ b/Samples/Panel_descriptor_Samples/Panel_descriptor_Sample_App.cpp
@@ -97,7 +97,7 @@ ctl_result_t GetPanelDescriptor(ctl_display_output_handle_t hDisplayOutput, ctl_
         ExtBlockPanelDescArgs                    = { 0 };
         ExtBlockPanelDescArgs.Size               = sizeof(ctl_panel_descriptor_access_args_t);
         ExtBlockPanelDescArgs.OpType             = CTL_OPERATION_TYPE_READ; // Currently only Read operation is supported. Write operationnot supported.
-        ExtBlockPanelDescArgs.BlockNumber        = BlockIndex;              // Block number
+        ExtBlockPanelDescArgs.BlockNumber        = BlockIndex + 1;              // Block number
         ExtBlockPanelDescArgs.DescriptorDataSize = ExtBlockDescriptorDataSize;
         ExtBlockPanelDescArgs.pDescriptorData    = (uint8_t *)malloc(ExtBlockDescriptorDataSize * sizeof(uint8_t)); // Allocate memory for the descriptor data
 


### PR DESCRIPTION
When querying for extension block data size, "BlockIndex + 1" is used as a BlockNumber, but when querying for the data itself, only "BlockIndex" is used instead